### PR TITLE
Copy 'include' proto files to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN make install-plugin
 FROM ubuntu:20.04
 
 COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /usr/local/include /usr/local/include
 
 ## Create the gRPC client
 ENV import_style=commonjs


### PR DESCRIPTION
This pull request allows proto files to import packages such as "google/protobuf/..." an issue I had when trying to use this.

[Related issue](https://stackoverflow.com/questions/62874455/import-google-protobuf-timestamp-proto-was-not-found-or-had-errors)